### PR TITLE
feat: support typescript and jsx files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,16 +18,19 @@ const convertToName = (str) => convertToPattern(str)
   .split(':').join('')
   .split('/').join('-')
 
-const ignoredFiles = ['_error.js', '_document.js', '_app.js']
+const ignoredFiles = ['_error', '_document', '_app'].reduce(
+  (memo, file) => memo.concat([`${file}.js`, `${file}.jsx`, `${file}.ts`, `${file}.tsx`]),
+  []
+)
 const addRoutesFromPath = (routes, opts, rel = '') => {
   fs.readdirSync(path.resolve(`${opts.root}/pages${rel}`)).forEach(file => {
     if (file.indexOf('.') === -1) {
       addRoutesFromPath(routes, opts, `${rel}/${file}`)
-    } else if (file.indexOf('.js') === -1 || (ignoredFiles.indexOf(file) !== -1 && rel === '')) {
+    } else if (!file.match(/\.(js|jsx|ts|tsx)$/) || (ignoredFiles.indexOf(file) !== -1 && rel === '')) {
       // ignore these
     } else {
       // its a valid file
-      file = file.replace('.js', '')
+      file = file.replace(/\.(js|jsx|ts|tsx)$/, '')
       const page = `${rel}/${file}`
       routes.add({
         page,


### PR DESCRIPTION
By using plugins, it's possible to have `.jsx`, `.ts` and `.tsx` files as entries in the `pages` folder.
This change supports them natively. 

It would also be possible to make the extension configurable.

Pre-released as `@xiphe/next-routing@0.3.0`